### PR TITLE
Update trial models to GPT-5 and Claude Haiku 4.5

### DIFF
--- a/src/eap/building-apps/build-ai-powered-apps/add-ai-models.md
+++ b/src/eap/building-apps/build-ai-powered-apps/add-ai-models.md
@@ -55,13 +55,13 @@ Trial models have limits, which, when reached, prevent the further use of the mo
 
 The following tables shows the current limits of the available Trial Models.
 
-#### GPT-4o
+#### GPT-5
 
 | Context | Maximum number of Requests | Requests rate limit | Maximum number of Tokens | Tokens Rate limit |
 | -- | -- | -- | -- | -- |
 | Licensed Customers | 100 | N.A. | N.A. | N.A. |
 
-#### Claude 3.7 Sonnet
+#### Claude Haiku 4.5
 
 | Context | Maximum number of Requests | Requests rate limit | Maximum number of Tokens | Tokens Rate limit |
 | -- | -- | -- | -- | -- |
@@ -101,7 +101,7 @@ Follow these steps to add an AI model connection or an ODC trial model in the OD
 
     * **Provider tab**: Select this tab to configure your own AI model from a supported provider or a custom connection.
 
-    * **Trial tab**: Select this tab to add a ready-to-use ODC trial model, for example, GPT or Claude Sonnet.
+    * **Trial tab**: Select this tab to add a ready-to-use ODC trial model, for example, GPT-5 or Claude Haiku 4.5.
 
 1. **For Provider tab**: Select your desired provider from the available options and click **Confirm** to proceed to the configuration details.
 

--- a/src/eap/building-apps/build-ai-powered-apps/ai-models.md
+++ b/src/eap/building-apps/build-ai-powered-apps/ai-models.md
@@ -38,7 +38,7 @@ Beyond native support for Azure OpenAI and Amazon Bedrock, ODC allows you to con
 
 When building your connector service, implement a supported authentication scheme and ensure its endpoint is accessible to ODC, potentially using a private gateway for non-public endpoints. The connector must process requests and format responses, including handling standard parameters like messages and temperature, according to the OutSystems API contract details. Your service should also return standard HTTP status codes for errors. Once your connector service is deployed and accessible, add it to the ODC Portal by selecting **Custom connection** as the provider type during the **Add AI model** process and entering your connector's URL and authentication details.
 
-![Screenshot of the 'Add AI model' interface in ODC Portal, showing options for Amazon Bedrock, Azure OpenAI, Custom connection, and trial models like GPT-4o and Claude 3.7 Sonnet.](images/custom-connection-pl.png "Add AI Model - Custom Connection")
+![Screenshot of the 'Add AI model' interface in ODC Portal, showing options for Amazon Bedrock, Azure OpenAI, Custom connection, and trial models like GPT-5 and Claude Haiku 4.5.](images/custom-connection-pl.png "Add AI Model - Custom Connection")
 
 For more information, download and inspect the [Swagger file](resources/swagger.json). Note that property names should use camelCase.
 

--- a/src/eap/building-apps/forge/submit.md
+++ b/src/eap/building-apps/forge/submit.md
@@ -55,7 +55,7 @@ By default, the asset name, icon, and short description are defined during devel
 
    <div class="info" markdown="1" >
 
-   When you are submitting Agentic apps, be aware that you can only submit Agent apps that use trial AI models. If you have a paid model, you need to adapt your app to use an Amazon Nova Pro or Claude 3.7 Sonnet trial models before you submit to Forge.
+   When you are submitting Agentic apps, be aware that you can only submit Agent apps that use trial AI models. If you have a paid model, you need to adapt your app to use an Amazon Nova Pro or Claude Haiku 4.5 trial models before you submit to Forge.
 
    </div>
 


### PR DESCRIPTION
## Summary

* Replace deprecated **GPT-4o** with **GPT-5** and **Claude 3.7 Sonnet** with **Claude Haiku 4.5** in the trial models documentation.
* Limits and table values remain unchanged.

## Files updated

* `src/eap/building-apps/build-ai-powered-apps/add-ai-models.md` — trial model section headings and Trial tab example.
* `src/eap/building-apps/build-ai-powered-apps/ai-models.md` — image alt text.
* `src/eap/building-apps/forge/submit.md` — Agentic apps note (Claude reference only; GPT not mentioned in this file).

## Test plan

- [ ] Verify rendered headings show GPT-5 and Claude Haiku 4.5
- [ ] Confirm limits tables are unchanged
- [ ] Run vale/markdownlint via CI
- [ ] Check no other pages reference the deprecated model names