### PR TITLE
ROU-12721: Updating CSP information for OutSystems Datagrid

### DIFF
--- a/src/eap/security/impacts-removing-unsafe-directives.md
+++ b/src/eap/security/impacts-removing-unsafe-directives.md
@@ -41,9 +41,13 @@ For more information about OutSystems Charts, refer to [OutSystems Charts](../re
 
 ### OutSystems data grid
 
+#### < v2.23.0
 * **Issue**: The **Calculated Column**  won't work.
 
     * **Workaround**: Avoid using **Calculated Columns**.
+
+#### >= v2.23.0
+* No known issues.
 
 For more inforamtion about OutSystems data grid, refer to [OutSystems Data Grid](../building-apps/ui/patterns/interaction/data-grid/data-grid-overview.md).
 

--- a/src/eap/security/impacts-removing-unsafe-directives.md
+++ b/src/eap/security/impacts-removing-unsafe-directives.md
@@ -41,13 +41,15 @@ For more information about OutSystems Charts, refer to [OutSystems Charts](../re
 
 ### OutSystems data grid
 
-#### < v2.23.0
-* **Issue**: The **Calculated Column**  won't work.
+* **Versions earlier than 2.23.0**
+
+    * **Issue**: The **Calculated Column**  won't work.
 
     * **Workaround**: Avoid using **Calculated Columns**.
 
-#### >= v2.23.0
-* No known issues.
+* **Version 2.23.0 or later**
+
+    * No known issues.
 
 For more information about OutSystems data grid, refer to [OutSystems Data Grid](../building-apps/ui/patterns/interaction/data-grid/data-grid-overview.md).
 

--- a/src/eap/security/impacts-removing-unsafe-directives.md
+++ b/src/eap/security/impacts-removing-unsafe-directives.md
@@ -49,7 +49,7 @@ For more information about OutSystems Charts, refer to [OutSystems Charts](../re
 #### >= v2.23.0
 * No known issues.
 
-For more inforamtion about OutSystems data grid, refer to [OutSystems Data Grid](../building-apps/ui/patterns/interaction/data-grid/data-grid-overview.md).
+For more information about OutSystems data grid, refer to [OutSystems Data Grid](../building-apps/ui/patterns/interaction/data-grid/data-grid-overview.md).
 
 ### OutSystems maps
 


### PR DESCRIPTION
This pull request updates the documentation for OutSystems Data Grid to clarify the impact of removing unsafe directives across different versions. The main change is to distinguish between issues affecting versions before and after v2.23.0.

Version-specific documentation updates:
* Added a new section indicating that for OutSystems Data Grid versions >= v2.23.0, there are no known issues related to removing unsafe directives.
* Clarified that the existing issue with Calculated Columns applies only to versions < v2.23.0.